### PR TITLE
Add sequential fade-in animation to hero text

### DIFF
--- a/src/component/HeroSection.js
+++ b/src/component/HeroSection.js
@@ -8,8 +8,12 @@ function HeroSection() {
         <section id="home" className="heroSection">
             <img src={image} className='heroSectionImg active' alt="Studio dentistico" />
             <div className="heroContent">
-                <h1>Il tuo sorriso, la nostra passione</h1>
-                <p>Cure dentistiche professionali per tutta la famiglia.</p>
+                <div className="heroTitle">
+                    <h1>Il tuo sorriso, la nostra passione</h1>
+                </div>
+                <div className="heroSubtitle">
+                    <p>Cure dentistiche professionali per tutta la famiglia.</p>
+                </div>
                 <a href="#contact" className="heroButton">Prenota visita</a>
             </div>
         </section>

--- a/src/component/heroSection.css
+++ b/src/component/heroSection.css
@@ -1,4 +1,16 @@
 /* Modernized hero section with gradient overlay and refreshed colours */
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .heroSection {
     position: relative;
     top: 0;
@@ -67,6 +79,18 @@
 .heroContent p {
     font-size: 1.25rem;
     margin-bottom: 2rem;
+}
+
+.heroTitle {
+    animation: fadeInUp 0.8s ease-out;
+    animation-delay: 0.2s;
+    animation-fill-mode: both;
+}
+
+.heroSubtitle {
+    animation: fadeInUp 0.8s ease-out;
+    animation-delay: 0.4s;
+    animation-fill-mode: both;
 }
 
 .heroButton {


### PR DESCRIPTION
## Summary
- wrap hero section heading and subtitle in dedicated containers
- animate hero text with fade-in-up effect and staggered delays

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ad82af8dbc832ab032b254c2b6363f