### PR TITLE
feat: rotate hero images

### DIFF
--- a/src/component/HeroSection.js
+++ b/src/component/HeroSection.js
@@ -1,12 +1,32 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './heroSection.css';
 
 function HeroSection() {
-    const image = "/heronew.png";
+    const images = [
+        "/heronew.png",
+        "/dentistaHeroSection.png",
+        "/dentidta2.png"
+    ];
+
+    const altTexts = [
+        "Studio dentistico moderno",
+        "Dentista al lavoro",
+        "Attrezzature odontoiatriche"
+    ];
+
+    const [currentIndex, setCurrentIndex] = useState(0);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setCurrentIndex((prevIndex) => (prevIndex + 1) % images.length);
+        }, 5000);
+
+        return () => clearInterval(interval);
+    }, [images.length]);
 
     return (
         <section id="home" className="heroSection">
-            <img src={image} className='heroSectionImg active' alt="Studio dentistico" />
+            <img src={images[currentIndex]} className='heroSectionImg active' alt={altTexts[currentIndex]} />
             <div className="heroContent">
                 <h1>Il tuo sorriso, la nostra passione</h1>
                 <p>Cure dentistiche professionali per tutta la famiglia.</p>

--- a/src/component/heroSection.css
+++ b/src/component/heroSection.css
@@ -29,19 +29,17 @@
     width: 100%;
     object-fit: cover;
     transform: scale(1.2);
-    transition: transform 2s ease;
     position: absolute;
     top: 0;
-    left: 100%;
+    left: 0;
     opacity: 0;
     z-index: 0;
-    transition: left 1s ease-out, transform 1s ease, opacity 1s ease;
+    transition: transform 2s ease, opacity 1s ease-in-out;
 }
 
 .heroSectionImg.active {
-    left: 0;
     opacity: 1;
-    transform: scale(1); /* Stato iniziale ingrandito */
+    transform: scale(1);
 }
 
 .heroSectionImg:hover {


### PR DESCRIPTION
## Summary
- cycle through an array of hero images with useEffect timer
- fade hero images smoothly via opacity transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad82a07400832a862407e5abbab211