### PR TITLE
Move home form into contact section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import Navbar from './component/Navbar';
 import HeroSection from './component/HeroSection'
 import Contact from './component/Contact';
 import ChiSiamo from './component/ChiSiamo';
-import FormHome from './component/FormHome';
 import Footer from './component/Footer';
 
 import './app.css'
@@ -14,8 +13,6 @@ function App() {
     <div className="App">
       <Navbar />
       <HeroSection />
-      <FormHome />
-
       <Contact />
       <ChiSiamo />
       <Footer />

--- a/src/component/Contact.js
+++ b/src/component/Contact.js
@@ -2,7 +2,8 @@ import React from "react";
 
 import Map from "./Map";
 import ContactInfo from "./ContactInfo";
-import ContactHero from "./ContactHero"
+import ContactHero from "./ContactHero";
+import FormHome from "./FormHome";
 
 import './contact.css';
 
@@ -13,10 +14,13 @@ function Contact() {
     return (
 
         <section id="contact" className="contactContent">
-            <ContactHero />
-            <ContactInfo />
+            <div className="contact-layout">
+                <ContactHero />
+                <ContactInfo />
+                <FormHome />
+            </div>
             <h3>
-                vieni a trovarci presso la nostra nuova sede 
+                vieni a trovarci presso la nostra nuova sede
             </h3>
             <h4>in via Corso Umberto I, 15</h4>
             <Map />

--- a/src/component/contact.css
+++ b/src/component/contact.css
@@ -12,6 +12,19 @@ background-color: #A5C4D4;
 
 }
 
+.contact-layout{
+  display: flex;
+  width: 100%;
+  gap: 2rem;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.contact-layout > *{
+  flex: 1 1 300px;
+}
+
  h3, h4{
     font-size: 1.6rem;
     background: linear-gradient(to right, #1a4b7b, #5d8484);
@@ -35,10 +48,13 @@ h3:hover{
 
 
 @media  (max-width: 680px) {
-
   .contactContent{
         border-radius: 25px 25px 0 0 ;
+  }
 
+  .contact-layout{
+    flex-direction: column;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove `FormHome` from the main app and relocate to the contact page
- Create a flexbox `contact-layout` wrapping hero, info and form components
- Add responsive styles for the new contact layout

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ad85816ef8832aaf339c945ca57c89