### PR TITLE
Refactor contact card with gradient layout

### DIFF
--- a/src/component/Card.js
+++ b/src/component/Card.js
@@ -1,15 +1,20 @@
 import React from "react";
-import './card.css'
+import './card.css';
 
-function Card() {
-
-    const imgUrl = './logoContatti.png'
-    return (
-
-        <img className="cardImg" src={imgUrl} alt="sds" />
-
-
-    )
+function Card({ image = './logoContatti.png', title, subtitle }) {
+  return (
+    <div className="card">
+      <div className="card-content">
+        <img className="card-img" src={image} alt={title || 'Card'} />
+        {(title || subtitle) && (
+          <div className="card-text">
+            {title && <h3 className="card-title">{title}</h3>}
+            {subtitle && <p className="card-subtitle">{subtitle}</p>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
-export default Card
+export default Card;

--- a/src/component/ContactHero.js
+++ b/src/component/ContactHero.js
@@ -1,17 +1,17 @@
 import React from "react";
 
-import Card from "./Card"
-import './contactHero.css'
+import Card from "./Card";
+import './contactHero.css';
 function ContactHero() {
     return (
         <div className="logoContatti">
-            <div className="cardImgDiv">
-                <Card />
-            </div>
-            <h3>Contattaci</h3>
-            <p> A DentalCare, combiniamo tecnologie all'avanguardia con un ambiente accogliente per offrire trattamenti di alta qualità in un'atmosfera rilassante. </p>
-
-        </div>)
+            <Card
+                title="Contattaci"
+                subtitle={"A DentalCare, combiniamo tecnologie all'avanguardia con un ambiente accogliente " +
+                "per offrire trattamenti di alta qualità in un'atmosfera rilassante."}
+            />
+        </div>
+    );
 }
 
 export default ContactHero;

--- a/src/component/card.css
+++ b/src/component/card.css
@@ -1,40 +1,46 @@
-
-.cardImgDiv{
-    height: 150px;
-    width: 150px;
-
-    border: 1px solid #789898;
-    border-radius: 50%;
-    flex: 1 ;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.card {
+  width: 200px;
+  border-radius: 15px;
+  background: linear-gradient(90deg, #30cfd0, #330867);
+  padding: 4px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.cardImg {
-  object-fit: cover;
+.card-content {
+  background: #ffffff;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.card-img {
   width: 100%;
-  height: 100%;
-
+  height: auto;
+  object-fit: cover;
 }
 
-
-.cardImgDiv:hover {
-
-    animation: flip 1.5s ease-in-out backwards infinite   ;
-}
-@keyframes flip {
-  0% {
-    transform: rotateY(0);
-  }
-  50% {
-    transform: rotateY(180deg);
-  }
-  100% {
-    transform: rotateY(360deg);
-  }
+.card-text {
+  padding: 0.5rem;
+  text-align: center;
 }
 
+.card-title {
+  font-size: 1.6rem;
+  background: linear-gradient(to right, #1a4b7b, #5d8484);
+  -webkit-background-clip: text;
+  color: transparent;
+  margin: 0;
+}
 
+.card-subtitle {
+  margin: 10px 0;
+  color: #394f4f;
+}
 
-
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+}

--- a/src/component/contactHero.css
+++ b/src/component/contactHero.css
@@ -1,9 +1,8 @@
-
 .logoContatti {
     position: relative;
     width: 60vw;
     height: 40vh;
-    max-width: 100vw; 
+    max-width: 100vw;
     flex: 3;
     display: flex;
     flex-direction: column;
@@ -11,22 +10,3 @@
     overflow: hidden;
     margin-top: 3vh;
 }
-.cardImgDiv{background-color: white;}
-
-.logoContatti h3{
-    font-size: 1.6rem;
-    background: linear-gradient(to right, #1a4b7b, #5d8484);
-    -webkit-background-clip: text;
-    color: transparent;
-    z-index: 90;
-}
-.logoContatti p {
-    text-align: center; /* Allineamento del testo */
-    margin: 10px 0; /* Spaziatura verticale */
-    color: #394f4f;
-    z-index: 90;
-
-}
-
-
-


### PR DESCRIPTION
## Summary
- restructure Card component to include optional title and subtitle
- apply gradient, shadows, and hover transitions to card
- update ContactHero to use new card layout

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad8593f568832abb1392d3ab2ea54a