### PR TITLE
Refine contact section styling with gradient and responsive tweaks

### DIFF
--- a/src/component/contact.css
+++ b/src/component/contact.css
@@ -5,11 +5,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-background-color: #A5C4D4;
-    border-radius: 25px 25px ;
-    margin-top: 5vh;
-    padding: 3vw ;
-
+  width: 100vw;
+  background: linear-gradient(135deg, rgba(48,207,208,0.6), rgba(51,8,103,0.6));
+  backdrop-filter: blur(10px);
+  border: 0.5px solid rgba(255,255,255,0.2);
+  box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+  border-radius: 25px 25px;
+  margin-top: 5vh;
+  padding: 3vw;
 }
 
  h3, h4{
@@ -35,10 +38,11 @@ h3:hover{
 
 
 @media  (max-width: 680px) {
-
   .contactContent{
-        border-radius: 25px 25px 0 0 ;
-
+    width: 100vw;
+    background: linear-gradient(135deg, rgba(48,207,208,0.6), rgba(51,8,103,0.6));
+    backdrop-filter: blur(10px);
+    border-radius: 25px 25px 0 0;
   }
 }
 

--- a/src/component/contactHero.css
+++ b/src/component/contactHero.css
@@ -30,3 +30,10 @@
 
 
 
+@media (max-width: 680px) {
+    .logoContatti {
+        width: 90vw;
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- Replace contact page background color with hero-style gradient and blur
- Expand contact section to full viewport width with matching border and shadow
- Adjust mobile layout for contact section and hero logo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad8588d3c4832ab9bba323ed96b47e