### PR TITLE
Refine contact section layout

### DIFF
--- a/src/component/Contact.js
+++ b/src/component/Contact.js
@@ -14,8 +14,8 @@ function Contact() {
     return (
 
         <section id="contact" className="contactContent">
+            <ContactHero />
             <div className="contact-layout">
-                <ContactHero />
                 <ContactInfo />
                 <FormHome />
             </div>

--- a/src/component/contact.css
+++ b/src/component/contact.css
@@ -16,7 +16,7 @@ background-color: #A5C4D4;
   display: flex;
   width: 100%;
   gap: 2rem;
-  justify-content: space-between;
+  justify-content: center;
   align-items: flex-start;
   flex-wrap: wrap;
 }

--- a/src/component/contactHero.css
+++ b/src/component/contactHero.css
@@ -1,12 +1,12 @@
 .logoContatti {
     position: relative;
-    width: 60vw;
+    width: 100%;
     height: 40vh;
-    max-width: 100vw;
-    flex: 3;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     overflow: hidden;
     margin-top: 3vh;
 }


### PR DESCRIPTION
## Summary
- Place contact hero above main layout for clearer structure
- Center contact info and form with simplified layout styles
- Expand hero container to full width for balanced design

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad88f4a0c0832a97f40d61a7564d82