### PR TITLE
Use public path for default Card image

### DIFF
--- a/src/component/Card.js
+++ b/src/component/Card.js
@@ -1,7 +1,9 @@
 import React from "react";
 import './card.css';
 
-function Card({ image = './logoContatti.png', title, subtitle }) {
+const defaultImage = process.env.PUBLIC_URL + '/logoContatti.PNG';
+
+function Card({ image = defaultImage, title, subtitle }) {
   return (
     <div className="card">
       <div className="card-content">


### PR DESCRIPTION
## Summary
- Load Card's default image from the public folder using process.env.PUBLIC_URL

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`
- `npm start` *(fails: Module not found: Can't resolve 'axios')*


------
https://chatgpt.com/codex/tasks/task_e_68ad8b300908832a9ff6c318488e61f8