### PR TITLE
Fix Leaflet marker icons

### DIFF
--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -1,7 +1,17 @@
 import 'leaflet/dist/leaflet.css';
 import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import L from 'leaflet';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
 
 import './map.css';
+
+L.Icon.Default.mergeOptions({
+    iconRetinaUrl,
+    iconUrl,
+    shadowUrl,
+});
 
 const Map = () => {
     const position = [41.725234, 13.342061];


### PR DESCRIPTION
## Summary
- import Leaflet and icon assets for markers
- configure default icon so markers render on maps

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ad8b36ec58832a93919c48de0ce218