### PR TITLE
Make contact hero section responsive

### DIFF
--- a/src/component/contactHero.css
+++ b/src/component/contactHero.css
@@ -1,12 +1,11 @@
 .logoContatti {
     position: relative;
     width: 100%;
-    height: 40vh;
+    min-height: 40vh;
     max-width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    overflow: hidden;
     margin-top: 3vh;
 }


### PR DESCRIPTION
## Summary
- replace fixed `height` with `min-height` in contact hero for responsiveness
- remove unnecessary `overflow` rule to prevent card truncation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm start` *(fails: Module not found: Can't resolve 'axios')*


------
https://chatgpt.com/codex/tasks/task_e_68ad91855be4832a88d553e9e763504d