### PR TITLE
Refactor contact layout with grid and glassmorphism cards

### DIFF
--- a/src/component/Contact.js
+++ b/src/component/Contact.js
@@ -14,8 +14,12 @@ function Contact() {
 
         <section id="contact" className="contactContent">
             <div className="contact-layout">
-                <ContactInfo />
-                <FormHome />
+                <div className="contact-card">
+                    <ContactInfo />
+                </div>
+                <div className="contact-card">
+                    <FormHome />
+                </div>
             </div>
 
             <Map />

--- a/src/component/contact.css
+++ b/src/component/contact.css
@@ -13,19 +13,21 @@ background-color: #A5C4D4;
 }
 
 .contact-layout{
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 70%;
-  gap: 2rem;
-  justify-content: center;
-  align-items: flex-start;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  width: 100%;
+  max-width: 90%;
+  gap: 3rem;
+  align-items: start;
+  margin: 0 auto;
   padding: 4em;
 }
 
-.contact-layout > *{
-  flex: 1 1 300px;
+.contact-card{
+  background: rgba(255,255,255,0.15);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  padding: 2rem;
 }
 
  h2, h3{
@@ -56,8 +58,7 @@ h2:hover{
   }
 
   .contact-layout{
-    flex-direction: column;
-    align-items: center;
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace flex layout with responsive grid for contact section
- wrap ContactInfo and FormHome in glassmorphism cards
- widen max-width and spacing for breathing room

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad976b61d4832a99fb81d085168722