### PR TITLE
Add icons and palette styling to contact info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-calendar": "^4.6.1",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.12.0",
         "react-leaflet": "^4.2.1",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.20.0",
@@ -15084,6 +15085,15 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^18.2.0",
     "react-calendar": "^4.6.1",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.12.0",
     "react-leaflet": "^4.2.1",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.20.0",

--- a/src/component/ContactInfo.js
+++ b/src/component/ContactInfo.js
@@ -1,5 +1,6 @@
 import React from "react";
 import TabOrari from "./TabOrari";
+import { FaPhone, FaEnvelope } from "react-icons/fa";
 import './contactInfo.css';
 
 function ContactInfo() {
@@ -10,8 +11,12 @@ function ContactInfo() {
         <div className="contattiDx">
             <TabOrari />
             <div className="contactDetails">
-                <p><a href={`tel:${telefono}`}>{telefono}</a></p>
-                <p><a href={`mailto:${email}`}>{email}</a></p>
+                <p><FaPhone className="icon" />
+                    <a href={`tel:${telefono}`}>{telefono}</a>
+                </p>
+                <p><FaEnvelope className="icon" />
+                    <a href={`mailto:${email}`}>{email}</a>
+                </p>
             </div>
         </div>
     );

--- a/src/component/contactInfo.css
+++ b/src/component/contactInfo.css
@@ -17,15 +17,31 @@
 
 .contactDetails {
     margin-top: 1rem;
-    text-align: center;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: center;
+}
+
+.contactDetails p {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
 }
 
 .contactDetails a {
-    color: #005f73;
+    color: #330867;
     text-decoration: none;
+    font-weight: 600;
 }
 
 .contactDetails a:hover {
     text-decoration: underline;
+    color: #30cfd0;
+}
+
+.contactDetails .icon {
+    color: #30cfd0;
 }


### PR DESCRIPTION
## Summary
- add phone and email icons via react-icons
- lay out contact details horizontally with flex and gap
- style links with palette colors and stronger weight

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad976caaac832aa8880023b11ca13e