### PR TITLE
Refine map layout and contact card styling

### DIFF
--- a/src/component/contactInfo.css
+++ b/src/component/contactInfo.css
@@ -8,11 +8,9 @@
     align-items: center;
     justify-content: center;
     z-index: 90;
-    border-radius: 5% 5% 0 0;
     background-color: transparent;
-
-
-
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .contactDetails {

--- a/src/component/formHome.css
+++ b/src/component/formHome.css
@@ -4,7 +4,7 @@
     background-color: #ffffff00; 
     padding: 2em;
     border-radius: 10px; /* Bordi arrotondati */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.263); 
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; 
     color: #333333; 
     max-width: 300px; 

--- a/src/component/map.css
+++ b/src/component/map.css
@@ -13,9 +13,9 @@
 .mapContainer{
     border-radius: 5%;
     overflow: hidden;
-    height: 35vw;
-    width: 45vw;
-    max-width: 65vw;
+    width: 100%;
+    max-width: 45rem;
+    height: 400px;
 }
 
 .leaflet-top {
@@ -32,11 +32,8 @@
   }
 }
 
-@media screen and (max-width: 400px){
+@media screen and (max-width: 600px){
   .mapContainer{
       height: 300px;
-      max-height: 300px;
-      width: 300px;
-      max-width: 300px;
   }
 }


### PR DESCRIPTION
## Summary
- Make map container responsive with full width, max width of 45rem, fixed 400px height, and shrink height on small screens
- Add consistent border radius and box shadow to contact section cards

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad976cf984832aaba8dbcb389b6c9a